### PR TITLE
Null tolerant rendering of rows (vdmeer/asciitable#14)

### DIFF
--- a/src/main/java/de/vandermeer/asciithemes/TA_GridHelpers.java
+++ b/src/main/java/de/vandermeer/asciithemes/TA_GridHelpers.java
@@ -100,7 +100,13 @@ public interface TA_GridHelpers {
 					}
 					if(l<(ar[k].length-1)){
 						if(testOption(HAS_CONTENT_MID, mode)){
-							al.add(TA_GridConfig.PT_VERTICAL | rowtype);
+							boolean rightAllNull = true;
+							for(int m=l+1; m<ar[k].length; m++){
+								rightAllNull = rightAllNull & (ar[k][m] == null);
+							}
+							if(!rightAllNull){
+								al.add(TA_GridConfig.PT_VERTICAL | rowtype);
+							}
 						}
 						else if(optionNeeded(HAS_CONTENT_MID, mode)){
 							al.add(TA_GridConfig.TYPE_NONE | rowtype);


### PR DESCRIPTION
IndexOutOfBoundsException happened when the value at last column is null, fix it by detecting the null cell  and merge it to its left cell.